### PR TITLE
docs(thermo): API.md for dmz and onboard

### DIFF
--- a/utils/thermo/dmz/API.md
+++ b/utils/thermo/dmz/API.md
@@ -1,0 +1,39 @@
+# DMZ HTTP API
+
+Flask application: import `app` from **`app`** after adding `thermo/dmz` to `PYTHONPATH` (or running with that directory on `sys.path`). Request/response shapes use Pydantic models in the same module; import **`ZoneRequest`**, **`ZoneReply`**, **`Sensors`**, **`IRCommand`**, **`ZoneState`** from **`app`**.
+
+Machine-auth header names and verification: **`zone_auth`** (`thermo/dmz/zone_auth.py`, same `PYTHONPATH` rule).
+
+---
+
+## `GET /login`
+
+Starts the Google OAuth redirect flow when OAuth credentials are configured. Returns `400` with a JSON error if OAuth is not configured.
+
+## `GET /authorize`
+
+OAuth callback: exchanges the authorization code, checks the Gmail address against `ALLOWED_EMAIL`, sets the session, and redirects to the zone listing. On failure returns `400`/`403` with JSON errors; if OAuth is disabled, redirects to `GET /zones`.
+
+## `GET /logout`
+
+Clears the session and redirects to login (if OAuth is enabled) or to `GET /zones`.
+
+## `POST /zone/<zonename>/sensors`
+
+Accepts JSON sensor readings for the named zone, appends them to in-memory state, and returns that zone’s current command and sensor snapshot. When `ZONE_PUBLIC_KEY` / `ZONE_PUBLIC_KEY_PATH` is set, the request must include valid Ed25519 zone signing headers matching the URL zone name.
+
+## `POST /zone/<zonename>/command`
+
+Accepts JSON to append an IR command for the zone and returns the zone snapshot. With a configured zone public key, either valid machine-signed requests or an authenticated browser session (when Google OAuth is enabled) may be used; otherwise OAuth may be required for human operators.
+
+## `GET /zones`
+
+Returns a JSON object of all known zones and each zone’s latest command and sensor state. Authorization follows `_authorize_global_read`: machine-signed request, OAuth session, or open access when neither machine auth nor OAuth is enforcing, depending on environment variables.
+
+## `GET /debug/logs`
+
+Returns a JSON object with a bounded in-memory list of recent HTTP access records (method, path, status, timestamp). Uses the same authorization rules as `GET /zones`.
+
+## `POST /test_reset`
+
+Test-only hook to replace in-memory `commands` and/or `sensors` from JSON body keys `commands` and `sensors`. Returns a short JSON string `"ok"`.

--- a/utils/thermo/onboard/API.md
+++ b/utils/thermo/onboard/API.md
@@ -1,0 +1,57 @@
+# Onboard HTTP API
+
+## Flask app (port `PORT`, default 5000)
+
+Import the WSGI/Flask instance as **`app`** from **`app`** after adding `thermo/onboard` to `PYTHONPATH`. Daikin command JSON maps to **`State`** in **`heatpumpirctl`** (`heatpumpirctl.State`, `State.from_json`, `State.to_json`). Static help text is in **`constants.help_msg`** (`constants`).
+
+---
+
+## `GET /<path>`
+
+Catch-all route for paths not matched by the explicit routes below (Flask’s `<path:path>` converter allows slashes in `path`). Returns simple HTML with the path and per-path request counts. Intended as a liveness or smoke check, not a stable API surface.
+
+## `GET /help` · `GET /about`
+
+Return JSON `{"msg": ...}` with the same help string from **`constants.help_msg`**.
+
+## `GET /environment`
+
+Returns JSON with current temperature and humidity (one decimal), plus an ISO timestamp. Uses the HTU21D sensor unless test fake values were injected via `POST /test/inject_readings`.
+
+## `POST /test/inject_readings`
+
+When running in a test environment (`common.is_test_env()`), sets fake temperature and humidity from JSON keys `temp_centigrade` and `humid_percent`. Returns `403` outside test env.
+
+## `GET /daikin`
+
+Returns a JSON array of recent Daikin commands (newest first), each entry with `time` and `command` (the `State` JSON).
+
+## `PUT /daikin` · `POST /daikin`
+
+Accepts JSON with a `command` object (or a top-level command dict), parses it as **`heatpumpirctl.State`**, sends it over IR, records it in the rolling queue, and returns `time`, `command`, and `sent` boolean.
+
+## `GET /logs`
+
+Returns JSON with up to the last 200 lines of the log file at `LOG_PATH` (key `lines`), or empty lines if the path is missing or unreadable.
+
+## `GET /manage`
+
+Returns JSON diagnostic snapshot (time, pid, log level, fake sensor values, Daikin queue size, selected env vars). Requires header **`X-Manage-Token`** to match **`MANAGE_TOKEN`**.
+
+## `POST /manage`
+
+Runs one management action from a JSON body (`action`, plus action-specific fields): inject log lines, change log level, reset state, or fault-injection paths (`assert`, `raise`, `fatal`). Requires the same **`X-Manage-Token`** as `GET /manage`.
+
+---
+
+## UI server (port `UI_PORT`, default 8080)
+
+Separate process: import **`Handler`**, **`main`** from **`ui_server`** with `thermo/onboard` on `PYTHONPATH`. Serves HTML that proxies to the Flask app on `127.0.0.1:$PORT`.
+
+## `GET /`
+
+Serves the thermostat HTML UI (reads latest state from Flask `GET /daikin`, environment line from `GET /environment`, embedded help from `GET /help` and `GET /about`, log excerpt from `GET /logs`).
+
+## `POST /`
+
+Accepts `application/x-www-form-urlencoded` body: either submits a Daikin update (POSTs JSON to Flask `POST /daikin`) or performs a management action (POSTs JSON to Flask `POST /manage` with token from form or `MANAGE_TOKEN` env). Responds with refreshed HTML and a status message.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `utils/thermo/dmz/API.md` and `utils/thermo/onboard/API.md` documenting each HTTP endpoint and verb with short descriptions. Type shapes are referenced via Python import paths (`app`, `zone_auth`, `heatpumpirctl`, `constants`, `ui_server`) rather than repeated in the docs.

## Notes

- Implementation remains under `thermo/dmz` and `thermo/onboard`; the new files live under `utils/thermo/` as requested.
- Onboard docs cover both the Flask app and the separate `ui_server` HTTP server on `UI_PORT`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c99964-c2fe-4772-a9cb-4e466cf8f5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c99964-c2fe-4772-a9cb-4e466cf8f5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

